### PR TITLE
Fixing typo in SQL for creating tables

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,7 +88,7 @@ CREATE UNIQUE INDEX journal_pidseq_idx ON journal (persistenceid, sequencenr);
 CREATE UNIQUE INDEX journal_rowid_idx ON journal (rowid);
 
 CREATE TABLE snapshot (
-   "persistenceid" VARCHAR(254) NOT NULL,....
+   "persistenceid" VARCHAR(254) NOT NULL,
    "sequencenr" INT NOT NULL,
    "timestamp" bigint NOT NULL,
    "snapshot" BYTEA,


### PR DESCRIPTION
Hey 👋!

There is a typo in main `README.adoc` with three dots `...`; perhaps it should not be there? This is a patch that removes this...

I also have this two questions; perhaps you can help me with...

1) In tests, you also create `GIN` index on `event`. That is impossible to do on JSON-type if you don't specify JSON key for `GIN`. Should that also be written in `README.adoc`?
2) Why are you using `VARCHAR` for `uuid fields` - why not `uuid` from Postgres?

Hope this helps someone out there, and thanks for your contribution! 👍 
