### PR TITLE
Add possibility to use hstore based on a -> instead of @>

### DIFF
--- a/modules/akka-persistence-pg/src/main/resources/reference.conf
+++ b/modules/akka-persistence-pg/src/main/resources/reference.conf
@@ -54,6 +54,7 @@ pg-persistence {
     }
   }
   pgjson = "json" //allowed values are 'json' and 'jsonb'
+  hstoreEquals = true // use "tags -> 'key' = value" instead of "tags @> hstore('key', 'value') for queries
   schemaName  = ""
   journalTableName = "journal"
   snapshotTableName = "snapshot"

--- a/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/AkkaPgJdbcTypes.scala
+++ b/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/AkkaPgJdbcTypes.scala
@@ -110,11 +110,15 @@ trait AkkaPgJdbcTypes extends JdbcTypesComponent { driver: PostgresProfile =>
       extends ExtensionMethods[Map[String, String], P1] {
 
     val Contains = new SqlOperator("@>")
+    val On       = new SqlOperator("->")
 
     protected implicit def b1Type: TypedType[Map[String, String]] = implicitly[TypedType[Map[String, String]]]
 
     def @>[P2, R](c2: Rep[P2])(implicit om: o#arg[Map[String, String], P2]#to[Boolean, R]): Rep[R] =
       om.column(Contains, n, c2.toNode)
+
+    def +>[P2, R](c2: Rep[P2])(implicit om: o#arg[String, P2]#to[String, R]): Rep[R] =
+      om.column(On, n, c2.toNode)
   }
 
 }

--- a/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/PluginConfig.scala
+++ b/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/PluginConfig.scala
@@ -52,6 +52,8 @@ class PluginConfig(systemConfig: Config) {
     case a: String => sys.error(s"unsupported value for pgjson '$a'. Only 'json' or 'jsonb' supported")
   })
 
+  val hstoreEquals: Boolean = config.getBoolean("hstoreEquals")
+
   lazy val database: JdbcBackend.DatabaseDef = createDatabase
 
   lazy val dbConfig: Config = config.getConfig("db")

--- a/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/journal/JournalStore.scala
+++ b/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/journal/JournalStore.scala
@@ -134,10 +134,17 @@ trait JournalStore extends JournalTable {
     */
   protected def tagsFilter(tags: Set[EventTag]): JournalTable => Rep[Boolean] = { table: JournalTable =>
     {
-      tags
-        .map { case (tagKey, tagValue) => table.tags @> Map(tagKey -> tagValue.value).bind }
-        .reduceLeftOption(_ || _)
-        .getOrElse(false: Rep[Boolean])
+      if (self.pluginConfig.hstoreEquals) {
+        tags
+          .map { case (tagKey, tagValue) => (table.tags +> tagKey) === tagValue }
+          .reduceLeftOption(_ || _)
+          .getOrElse(false: Rep[Boolean])
+      } else {
+        tags
+          .map { case (tagKey, tagValue) => table.tags @> Map(tagKey -> tagValue.value).bind }
+          .reduceLeftOption(_ || _)
+          .getOrElse(false: Rep[Boolean])
+      }
     }
   }
 


### PR DESCRIPTION
I found that when using tags (HSTORE) I get better performance when I use
`tags->'key' = 'value'` instead of `tags @> hstore('key', 'value')` in the case when there are tags that are very infrequent.

With the -> variant I can create an index of the key (e.g. `create index "tag_portEvent" on "journal" ((tags -> 'PortEvent'), id);`) and then postgres will make use of that index:
```
Aggregate  (cost=140.43..140.44 rows=1 width=8) (actual time=0.014..0.014 rows=1 loops=1)
  ->  Bitmap Heap Scan on journal  (cost=9.20..140.34 rows=34 width=8) (actual time=0.013..0.013 rows=0 loops=1)
        Recheck Cond: ((((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FIssueTypeUpdated'::text) AND (id >= 0)) OR (((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FChildIssuesUpdated'::text) AND (id >= 0)))
        ->  BitmapOr  (cost=9.20..9.20 rows=34 width=0) (actual time=0.012..0.012 rows=0 loops=1)
              ->  Bitmap Index Scan on "tag_portEvent"  (cost=0.00..4.59 rows=17 width=0) (actual time=0.010..0.010 rows=0 loops=1)
                    Index Cond: (((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FIssueTypeUpdated'::text) AND (id >= 0))
              ->  Bitmap Index Scan on "tag_portEvent"  (cost=0.00..4.59 rows=17 width=0) (actual time=0.002..0.002 rows=0 loops=1)
                    Index Cond: (((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FChildIssuesUpdated'::text) AND (id >= 0))
Planning Time: 0.156 ms
Execution Time: 0.034 ms
```

with @>  it'll do a long table scan:
```
Result  (cost=12.07..12.08 rows=1 width=8) (actual time=113.636..113.636 rows=1 loops=1)
  InitPlan 1 (returns $0)
    ->  Limit  (cost=0.42..12.07 rows=1 width=8) (actual time=113.633..113.633 rows=0 loops=1)
          ->  Index Scan Backward using journal_pkey on journal  (cost=0.42..20055.04 rows=1722 width=8) (actual time=113.632..113.632 rows=0 loops=1)
                Index Cond: ((id IS NOT NULL) AND (id >= 0))
                Filter: (((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FIssueTypeUpdated'::text) OR ((tags -> 'PortEvent'::text) = 'a/%2Fprocess-engine%2FChildIssuesUpdated'::text))
                Rows Removed by Filter: 172253
Planning Time: 0.727 ms
Execution Time: 113.663 ms
```
Neither a gin nor a gist index on tags will prevent that.


I',m aware that this isn't an optimisation in all cases, that's why I made it configurable via a config flag:
`hstoreEquals = true // use "tags -> 'key' = value" instead of "tags @> hstore('key', 'value') for queries`
