### PR TITLE
unwrap Tagged from akka persistence

### DIFF
--- a/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/journal/JournalStore.scala
+++ b/modules/akka-persistence-pg/src/main/scala/akka/persistence/pg/journal/JournalStore.scala
@@ -9,6 +9,7 @@ import akka.persistence.pg.{EventTag, JsonString, PgConfig, PgExtension}
 import akka.serialization.{Serialization, Serializers}
 
 import scala.util.Try
+import akka.persistence.journal.Tagged
 
 /**
   * The journal/event store: it stores persistent messages.
@@ -64,6 +65,7 @@ trait JournalStore extends JournalTable {
       messages map { message =>
         val event = message.payload match {
           case w: EventWrapper[_] => w.event
+          case w: Tagged          => w.payload
           case _                  => message.payload
         }
         val tags: Map[String, String] = eventTagger.tags(message.payload)


### PR DESCRIPTION
see #46 

This unwrapps `akka.persistence.journal.Tagged` values when creating a journal entry. It does not save the Tags from Tagged as there is no single-best way to map the Set[String] to a Map[String,String] for HStore.  We could teach the `akka.persistence.pg.event.DefaultTagger` to do it pretty easily.

This PR is missing a test, I didn't find the correct place/way to put the test. Could you help me with that?